### PR TITLE
type_for_unit was comparing with incorrect case for Bco16 types.

### DIFF
--- a/simconnect/scvars.py
+++ b/simconnect/scvars.py
@@ -62,7 +62,7 @@ def type_for_unit(unit: str) -> int:
     if unit in UNITS:
         u = UNITS[unit]
         if u['dimensions'] == 'Miscellaneous Units':
-            if u['name_std'] in ('Bool', 'Boolean', 'Enum', 'BCO16', 'mask', 'flags'):
+            if u['name_std'] in ('Bool', 'Boolean', 'Enum', 'Bco16', 'mask', 'flags'):
                 return DATATYPE_INT32
             elif u['name_std'] == 'string':
                 return DATATYPE_STRING256


### PR DESCRIPTION
I found that Bco16 data types were being unrecognized, and stepping through I found that u['name_std'] was being set to 'Bco16', but compared to 'BCO16', which I think is incorrect. The type is correctly set with this change.
